### PR TITLE
fix: nuxt composition api preset name

### DIFF
--- a/examples/nuxt/nuxt.config.js
+++ b/examples/nuxt/nuxt.config.js
@@ -7,6 +7,6 @@ export default {
     // <script setup> transformer
     'unplugin-vue2-script-setup/nuxt',
     // api auto import
-    ['unplugin-auto-import/nuxt', { imports: ['@nuxt/composition-api'] }],
+    ['unplugin-auto-import/nuxt', { imports: ['@nuxtjs/composition-api'] }],
   ],
 }

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -11,7 +11,7 @@ import vueuseHead from './vueuse-head'
 import nuxtCompositionApi from './nuxt-composition-api'
 
 export type PresetName =
-  | '@nuxt/composition-api'
+  | '@nuxtjs/composition-api'
   | '@vue/composition-api'
   | '@vueuse/core'
   | '@vueuse/head'
@@ -23,7 +23,7 @@ export type PresetName =
   | 'vue'
 
 export const presets: Record<PresetName, ImportsMap | (() => ImportsMap)> = {
-  '@nuxt/composition-api': nuxtCompositionApi,
+  '@nuxtjs/composition-api': nuxtCompositionApi,
   '@vue/composition-api': vueCompositionApi,
   '@vueuse/core': vueuseCore,
   '@vueuse/head': vueuseHead,

--- a/src/presets/nuxt-composition-api.ts
+++ b/src/presets/nuxt-composition-api.ts
@@ -2,7 +2,7 @@ import { ImportsMap } from '../types'
 import { CommonCompositionAPI } from './vue'
 
 export default <ImportsMap>({
-  '@nuxt/composition-api': [
+  '@nuxtjs/composition-api': [
     ...CommonCompositionAPI,
 
     // nuxt hooks


### PR DESCRIPTION
Updates preset name from `@nuxt/composition-api` to `@nuxtjs/composition-api` as it generates incorrect imports