### PR TITLE
feat: add defineAsyncComponent to the composition api methods

### DIFF
--- a/src/presets/vue.ts
+++ b/src/presets/vue.ts
@@ -31,6 +31,7 @@ export const CommonCompositionAPI = [
 
   // component
   'defineComponent',
+  'defineAsyncComponent',
   'getCurrentInstance',
   'h',
   'inject',
@@ -46,7 +47,6 @@ export default <ImportsMap>({
 
     // vue3 only
     'triggerRef',
-    'defineAsyncComponent',
     'onDeactivated',
     'onServerPrefetch',
     'onErrorCaptured',


### PR DESCRIPTION
`defineAsyncComponent` is available in `@vue/composition-api`: https://github.com/vuejs/composition-api/pull/644

Needed for https://github.com/antfu/unplugin-vue2-script-setup/issues/43 to work with `unplugin-auto-import`