### PR TITLE
 feat: add triggerRef to the composition api methods 

### DIFF
--- a/src/presets/vue.ts
+++ b/src/presets/vue.ts
@@ -22,6 +22,7 @@ export const CommonCompositionAPI = [
   'shallowReactive',
   'shallowReadonly',
   'shallowRef',
+  'triggerRef',
   'toRaw',
   'toRef',
   'toRefs',
@@ -46,7 +47,6 @@ export default <ImportsMap>({
     ...CommonCompositionAPI,
 
     // vue3 only
-    'triggerRef',
     'onDeactivated',
     'onServerPrefetch',
     'onErrorCaptured',

--- a/test/__snapshots__/dts.test.ts.snap
+++ b/test/__snapshots__/dts.test.ts.snap
@@ -22,6 +22,7 @@ declare global {
   const shallowReactive: typeof import('vue-demi')['shallowReactive']
   const shallowReadonly: typeof import('vue-demi')['shallowReadonly']
   const shallowRef: typeof import('vue-demi')['shallowRef']
+  const triggerRef: typeof import('vue-demi')['triggerRef']
   const toRaw: typeof import('vue-demi')['toRaw']
   const toRef: typeof import('vue-demi')['toRef']
   const toRefs: typeof import('vue-demi')['toRefs']


### PR DESCRIPTION
`triggerRef` is supported by composition-api: https://github.com/vuejs/composition-api/blob/07cad7236ad1201f409541c5073c8d4fd19c900e/src/reactivity/index.ts#L18