### PR TITLE
fix: added PropType to vue

### DIFF
--- a/src/presets/vue.ts
+++ b/src/presets/vue.ts
@@ -40,6 +40,7 @@ export const CommonCompositionAPI = [
   'provide',
   'useCssModule',
   'createApp',
+  'PropType',
 ]
 
 export default <ImportsMap>({


### PR DESCRIPTION
Used to type some props like:
items: Array as PropType<Array<number>>,