### PR TITLE
fix: eslint globals config, fixes #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,35 @@ build({
 
 <br></details>
 
+
+<details>
+<summary>eslint</summary><br>
+
+- imports  - AutoImport `imports` Configuration.
+
+- propValue - eslint globals `propValue`, default `true`. 
+
+  - [options] : `true | false | 'readonly' | 'readable' | 'writable' | 'writeable'`
+
+> Note: eslint globals Docs - https://eslint.org/docs/user-guide/configuring/language-options#specifying-globals
+
+**Usage**
+
+```ts
+// .eslintrc.js
+const AutoImportESLintGlobals = require('unplugin-auto-import/eslint');
+
+module.exports = { 
+  /* ... */
+  globals: {
+    ...AutoImportESLintGlobals(/* imports */, /* propValue */),
+  },
+}
+
+```
+
+<br></details>
+
 ## Configuration
 
 ```ts

--- a/eslint.d.ts
+++ b/eslint.d.ts
@@ -1,0 +1,1 @@
+export { default } from './dist/eslint'

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
     "./esbuild": {
       "require": "./dist/esbuild.js",
       "import": "./dist/esbuild.mjs"
+    },
+    "./eslint": {
+      "require": "./dist/eslint.js",
+      "import": "./dist/eslint.mjs"
     }
   },
   "main": "dist/index.js",

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -1,0 +1,29 @@
+import { toArray } from '@antfu/utils'
+import { } from 'eslint/index'
+import { presets } from './presets'
+import type { Options } from './types'
+
+type globalsPropValue = boolean | 'readonly' | 'readable' | 'writable' | 'writeable'
+
+function AutoImportESLintGlobals(imports: Options['imports'], propValue: globalsPropValue = true) {
+  const globals: { [name: string]: globalsPropValue } = {}
+  toArray(imports).forEach((definition) => {
+    if (typeof definition === 'string') {
+      if (!presets[definition])
+        throw new Error(`[auto-import] preset ${definition} not found`)
+      const preset = presets[definition]
+      definition = typeof preset === 'function' ? preset() : preset
+    }
+
+    for (const mod of Object.keys(definition)) {
+      definition[mod].forEach((key) => {
+        const importName = Array.isArray(key) ? key[1] : key
+        globals[importName] = propValue
+      })
+    }
+  })
+
+  return globals
+}
+
+export default AutoImportESLintGlobals


### PR DESCRIPTION
fix: Is it feasible to automatically generate a list with auto imported api names for ESLint config file
eslint globals Docs: https://eslint.org/docs/user-guide/configuring/language-options#specifying-globals

#69 