### PR TITLE
fix: preact hook apis should be imported from 'preact/hooks'

### DIFF
--- a/src/presets/preact.ts
+++ b/src/presets/preact.ts
@@ -1,7 +1,7 @@
 import type { ImportsMap } from '../types'
 
 export default <ImportsMap>({
-  preact: [
+  'preact/hooks': [
     'useState',
     'useCallback',
     'useMemo',


### PR DESCRIPTION
According to an official [Preact](https://preactjs.com/guide/v10/hooks) document about importing hooks APIs, it should be imported from `preact/hooks`, not from `preact`.