### PR TITLE
refactor(ctx): adjust the usage of throttle

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -80,7 +80,7 @@ export function createContext(options: Options = {}, root = process.cwd()) {
     return generateESLintConfigs(await unimport.getImports(), eslintrc)
   }
 
-  const writeConfigFilesThrottled = throttle(500, false, writeConfigFiles)
+  const writeConfigFilesThrottled = throttle(500, writeConfigFiles, { noTrailing: false })
 
   let lastDTS: string | undefined
   let lastESLint: string | undefined


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Upstream `@antfu/utils` upgraded the `throttle-debounce` dependency, resulting in abnormal usage of `throttle` used by `writeConfigFilesThrottled`

### Error message
TypeError: callback.apply is not a function

### Additional context
where the problem is：https://github.com/antfu/utils/commit/4bd2e2bf9a6776abe9b37589e20f617187e433b9#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R61

The `throttle` of `throttle-debounce` is in the corresponding version of the code

old：https://github.com/niksy/throttle-debounce/blob/v3.0.1/throttle.js#L19
now：https://github.com/niksy/throttle-debounce/blob/master/throttle.js#L24
