### PR TITLE
fix: scanDirs when nested modules in dirs update

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@rollup/pluginutils": "^5.0.2",
     "local-pkg": "^0.4.3",
     "magic-string": "^0.27.0",
+    "minimatch": "^6.2.0",
     "unimport": "^2.2.4",
     "unplugin": "^1.0.1"
   },

--- a/playground/App.vue
+++ b/playground/App.vue
@@ -2,6 +2,7 @@
 import HelloWorld from './HelloWorld.vue'
 ElMessage.warning('Test')
 const foo = useFoo()
+const bar = useBar()
 </script>
 
 <script lang="ts">
@@ -18,6 +19,7 @@ export default defineComponent({
 <template>
   <HelloWorld msg="hi" />
   <pre>{{ foo }}</pre>
+  <pre>{{ bar }}</pre>
   <pre>{{ FOOBAR }}</pre>
   <div v-loading="false">
     <ElButton>Hello</ElButton>

--- a/playground/composables/nested/bar.ts
+++ b/playground/composables/nested/bar.ts
@@ -1,0 +1,3 @@
+export function useBar() {
+  return 'bar from ./composables/nested/'
+}

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         ElementPlusResolver(),
       ],
       dirs: [
-        './composables',
+        './composables/**',
       ],
       vueTemplate: true,
       cache: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ importers:
       fast-glob: ^3.2.12
       local-pkg: ^0.4.3
       magic-string: ^0.27.0
+      minimatch: ^6.2.0
       rollup: ^3.14.0
       tsup: ^6.5.0
       typescript: ^4.9.5
@@ -33,6 +34,7 @@ importers:
       '@rollup/pluginutils': 5.0.2_rollup@3.14.0
       local-pkg: 0.4.3
       magic-string: 0.27.0
+      minimatch: 6.2.0
       unimport: 2.2.4_rollup@3.14.0
       unplugin: 1.0.1
     devDependencies:
@@ -5406,6 +5408,13 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
     dev: true
+
+  /minimatch/6.2.0:
+    resolution: {integrity: sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimist/1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -1,3 +1,5 @@
+import minimatch from 'minimatch'
+import { slash } from '@antfu/utils'
 import { createUnplugin } from 'unplugin'
 import type { Options } from '../types'
 import { createContext } from './ctx'
@@ -24,7 +26,7 @@ export default createUnplugin<Options>((options) => {
     },
     vite: {
       async handleHotUpdate({ file }) {
-        if (ctx.dirs?.some(dir => file.startsWith(dir)))
+        if (ctx.dirs?.some(glob => minimatch(slash(file), glob)))
           await ctx.scanDirs()
       },
       async configResolved(config) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When use nested modules in dirs, handleHotUpdate is not re-scanDirs.

```ts
  dirs: [
    // './composables/**', // all nested modules
  ],
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
