### PR TITLE
feat(injectAtEnd): add new option

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -31,11 +31,14 @@ export function createContext(options: Options = {}, root = process.cwd()) {
   const cachePath = isCache === false
     ? false
     : resolve(root, typeof isCache === 'string' ? isCache : 'node_modules/.cache/unplugin-auto-import.json')
+  
+  // When "options.injectAtEnd" is undefined or true, it's true.
+  const injectAtEnd = options.injectAtEnd !== false
 
   const unimport = createUnimport({
     imports: [],
     presets: [],
-    injectAtEnd: true,
+    injectAtEnd,
     addons: [
       ...(options.vueTemplate ? [vueTemplateAddon()] : []),
       resolversAddon(resolvers),

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,13 @@ export interface Options {
   ignore?: (string | RegExp)[]
 
   /**
+   * Inject the imports at the end of other imports
+   *
+   * @default true
+   */
+  injectAtEnd?: boolean
+
+  /**
    * Path for directories to be auto imported
    */
   dirs?: string[]


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
add new option about **unimport**. 

> 💡Inject the imports at the end of other imports

The default value is **true** for the current version, which has no effect on upgrades.
### Linked Issues
no.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
My config is 
```ts
AutoImport({
  imports: [
    'vue',
    'vue/macros',
    'vue-router',
    'vue-i18n',
    '@vueuse/core',
    'pinia',
    {
      vue: ['createVNode'],
      '@/i18n/use-locale': ['dayjs'],
      '@/utils/use-search': [['default', 'useSearch']],
      '@/utils/emitter': [['default', 'emitter']],
      '@/utils/page-tab-util': [
        'finishPageTab',
        'removePageTab',
        'setPageTab'
      ],
      '@/store/modules/theme': ['useThemeStore'],
      '@/store/modules/dict': ['useDictStore'],
      '@/store/modules/user': ['useUserStore'],
      'ant-design-vue': ['message', 'Modal'],
      '@ant-design/icons-vue': ['ExclamationCircleOutlined'],
      'ant-design-vue/es/form': ['useForm'],
      'ele-admin-pro': ['assignObject', 'emailReg', 'phoneReg'],
      'file-saver': ['saveAs'],
      qs: [['stringify', 'qsStringify']],
      '@vueuse/integrations/useCookies': ['useCookies']
    }
  ],
  dts: 'types/auto-imports.d.ts',
  dirs: [...API_DIR],
  vueTemplate: true,
  resolvers: [VueAmapResolver()]
})
```
In my project has some error, 
![image](https://user-images.githubusercontent.com/65681376/220149400-22105288-6000-48bb-b326-64b4a323fb42.png)
![image](https://user-images.githubusercontent.com/65681376/220149690-e5321cfb-3f4c-4e15-a313-21a4dcf82531.png)

I tried downgrading many versions and finally determined that 0.12.2 works fine, and 0.13.0 or later doesn't work.

By looking up the git logs, I found that the `injectAtEnd: true` attribute is the cause of this error.

For better compatibility, so I created this PR.
