### PR TITLE
fix: resolve ignore error with cache

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -197,10 +197,14 @@ ${dts}`.trim()}\n`
         else
           delete cacheData[filePath]
         writeFileThrottled(cachePath, JSON.stringify(cacheData, null, 2))
-        return imports.concat(importList)
+        return imports
       }
 
-      return imports.concat(Object.values(cacheData).reduce((p, n) => p.concat(n), []))
+      const map = await unimport.getImportMap();
+      const cacheImports = Object.values(cacheData)
+        .reduce((p, n) => p.concat(n), [])
+        .filter((i) => !(map.get(i.as ?? i.name)?.from === i.from))
+      return imports.concat(cacheImports)
     })
   }
 


### PR DESCRIPTION
## related change

https://github.com/unjs/unimport/pull/237

## description

when my options like this:

isProxy and h is in vue
```js
      ignore: ['isProxy', 'h'],
      exclude: [/\.remote/],
      cache: true,
      imports: [
        'vue',
        {
          'vue-router': [
            'useLink',
            'useRoute',
            'useRouter',
            'onBeforeRouteLeave',
            'onBeforeRouteUpdate',
            'createRouter',
            'createWebHistory',
          ],
        },
      ],
```

but now I used cache.

in cache.json, have the same Api like this

```json
    {
      "from": "vue",
      "name": "watchEffect",
      "as": "watchEffect"
    },
    {
      "from": "vue",
      "name": "reactive",
      "as": "reactive"
    },
```

the same Api caused the dedupeImports delete error.

![image](https://user-images.githubusercontent.com/46661044/229707445-336345cb-8d76-4bd3-a066-c9fb795e170f.png)


if I filter the cacheImports, everything is ok.

```js
     const map = await unimport.getImportMap();
      const cacheImports = Object.values(cacheData)
        .reduce((p, n) => p.concat(n), [])
        .filter((i) => !(map.get(i.as ?? i.name)?.from === i.from))
      return imports.concat(cacheImports)
```


