### PR TITLE
fix: avoid warning when not needed, fix #314

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -57,7 +57,7 @@ ${dts}`.trim()}\n`
 
   const importsPromise = flattenImports(options.imports)
     .then((imports) => {
-      if (!imports.length && !resolvers.length)
+      if (!imports.length && !resolvers.length && !dirs?.length)
         console.warn('[auto-import] plugin installed but no imports has defined, see https://github.com/antfu/unplugin-auto-import#configurations for configurations')
 
       options.ignore?.forEach((name) => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hi,

First of all, I wanted to thank you for creating and maintaining `unplugin-auto-import`. I recently started using it in my project after it was recommended by Posva, and I have found it to be very helpful.

However, I ran into a tiny issue with the warning message that is displayed when no imports are defined. After investigating the issue, I realized that the warning message is not necessary in all cases, especially when the "dirs" option is specified.

To fix this issue, I modified the source code to check for the "dirs" option and skip the warning message if it is specified. Here is an example of how I use this package in my project:

```ts
require('unplugin-auto-import/webpack')({
  dirs: [path.resolve(__dirname, '../../app/javascript/stores')],
  dts: path.resolve(__dirname, '../../app/javascript/auto-imports.d.ts'),
}),
```
I do not need to define any imports explicitly. However, the warning message is displayed because no imports are defined.

With my modification, the warning message will not be displayed when the "dirs" option is specified, and the package will work as expected for my use case. This modification was partially requested in issue #314.

Thank you again for your contribution to the community, and I hope you find this modification useful. Please let me know if you have any questions or suggestions for improvement.

### Linked Issues

#314

