### PR TITLE
fix: slash dir glob to support windows match

### DIFF
--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -25,7 +25,7 @@ export default createUnplugin<Options>((options) => {
     },
     vite: {
       async handleHotUpdate({ file }) {
-        if (ctx.dirs?.some(glob => minimatch(slash(file), glob)))
+        if (ctx.dirs?.some(glob => minimatch(slash(file), slash(glob))))
           await ctx.scanDirs()
       },
       async configResolved(config) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

[minimatch](https://github.com/isaacs/minimatch#windows) must require `/`, even for `glob`，dir glob will not be slashed when it is resolved in windows, so I mentioned this pr。This enables directories to be rescanned when hmr on windows

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
