### PR TITLE
feat: support rspack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/unplugin-auto-import?color=a1b858&label=)](https://www.npmjs.com/package/unplugin-auto-import)
 
-Auto import APIs on-demand for Vite, Webpack, Rollup and esbuild. With TypeScript support. Powered by [unplugin](https://github.com/unjs/unplugin).
+Auto import APIs on-demand for Vite, Webpack, rspack, Rollup and esbuild. With TypeScript support. Powered by [unplugin](https://github.com/unjs/unplugin).
 
 ---
 
@@ -95,6 +95,21 @@ module.exports = {
   /* ... */
   plugins: [
     require('unplugin-auto-import/webpack')({ /* options */ }),
+  ],
+}
+```
+
+<br></details>
+
+<details>
+<summary>rspack</summary><br>
+
+```ts
+// rspack.config.js
+module.exports = {
+  /* ... */
+  plugins: [
+    require('unplugin-auto-import/rspack')({ /* options */ }),
   ],
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/unplugin-auto-import?color=a1b858&label=)](https://www.npmjs.com/package/unplugin-auto-import)
 
-Auto import APIs on-demand for Vite, Webpack, rspack, Rollup and esbuild. With TypeScript support. Powered by [unplugin](https://github.com/unjs/unplugin).
+Auto import APIs on-demand for Vite, Webpack, Rspack, Rollup and esbuild. With TypeScript support. Powered by [unplugin](https://github.com/unjs/unplugin).
 
 ---
 
@@ -102,7 +102,7 @@ module.exports = {
 <br></details>
 
 <details>
-<summary>rspack</summary><br>
+<summary>Rspack</summary><br>
 
 ```ts
 // rspack.config.js

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "astro",
     "webpack",
     "rollup",
+    "rspack",
     "auto-import",
     "transform"
   ],
@@ -61,6 +62,11 @@
       "types": "./dist/webpack.d.ts",
       "require": "./dist/webpack.cjs",
       "import": "./dist/webpack.js"
+    },
+    "./rspack": {
+      "types": "./dist/rspack.d.ts",
+      "require": "./dist/rspack.cjs",
+      "import": "./dist/rspack.js"
     },
     "./esbuild": {
       "types": "./dist/esbuild.d.ts",

--- a/src/rspack.ts
+++ b/src/rspack.ts
@@ -1,0 +1,5 @@
+import type { Options } from './types'
+import unplugin from '.'
+
+// TODO: some upstream lib failed generate invalid dts, remove the any in the future
+export default unplugin.rspack as (options?: Options) => any


### PR DESCRIPTION
### Description

This PR adds an `rspack` export to the package, using unplugin's experimental [rspack](https://www.rspack.dev/) support.

### Linked Issues

This has not been brought up yet.

### Additional context

rspack just recently [added support](https://github.com/web-infra-dev/rspack/issues/2350) for vue-loader. As far as I have tested it, this works flawlessly. Having Vue support in rspack was a good occasion to look for rspack support in some popular build tools that commonly come with Vue projects.