### PR TITLE
feat: dirs add `exportAllByFileName` config (#388)

### DIFF
--- a/playground/App.vue
+++ b/playground/App.vue
@@ -2,8 +2,11 @@
 import HelloWorld from './HelloWorld.vue'
 
 ElMessage.warning('Test')
-const foo = useFoo()
-const bar = useBar()
+const composableFoo = useFoo()
+const composableBar = useBar()
+
+const utilsFoo = foo.useFoo()
+const utilsBar = bar.useBar()
 </script>
 
 <script lang="ts">
@@ -19,8 +22,10 @@ export default defineComponent({
 
 <template>
   <HelloWorld msg="hi" />
-  <pre>{{ foo }}</pre>
-  <pre>{{ bar }}</pre>
+  <pre>{{ composableFoo }}</pre>
+  <pre>{{ composableBar }}</pre>
+  <pre>{{ utilsFoo }}</pre>
+  <pre>{{ utilsBar }}</pre>
   <pre>{{ FOOBAR }}</pre>
   <div v-loading="false">
     <ElButton>Hello</ElButton>

--- a/playground/utils/foo.ts
+++ b/playground/utils/foo.ts
@@ -1,0 +1,3 @@
+export function useFoo() {
+  return 'foo from ./utils/'
+}

--- a/playground/utils/nested/bar.ts
+++ b/playground/utils/nested/bar.ts
@@ -1,0 +1,3 @@
+export function useBar() {
+  return 'bar from ./utils/nested/'
+}

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -15,9 +15,12 @@ export default defineConfig({
       ],
       dirs: [
         './composables/**',
+        {
+          dir: './utils/**',
+          exportAllByFileName: true,
+        },
       ],
       vueTemplate: true,
-      cache: true,
     }),
   ],
 })

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -1,5 +1,5 @@
 import { minimatch } from 'minimatch'
-import { slash } from '@antfu/utils'
+import { isString, slash } from '@antfu/utils'
 import { createUnplugin } from 'unplugin'
 import type { Options } from '../types'
 import { createContext } from './ctx'
@@ -23,7 +23,7 @@ export default createUnplugin<Options>((options) => {
     },
     vite: {
       async handleHotUpdate({ file }) {
-        if (ctx.dirs?.some(glob => minimatch(slash(file), slash(glob))))
+        if (ctx.dirs?.some(glob => minimatch(slash(file), isString(glob) ? glob : glob.dir)))
           await ctx.scanDirs()
       },
       async configResolved(config) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,11 @@ export type Resolver = ResolverFunction | ResolverResultObject
  */
 export type ImportsMap = Record<string, (string | ImportNameAlias)[]>
 
+export interface DirsOptions {
+  dir: string
+  exportAllByFileName?: boolean
+}
+
 export type ESLintGlobalsPropValue = boolean | 'readonly' | 'readable' | 'writable' | 'writeable'
 
 export interface ESLintrc {
@@ -93,7 +98,7 @@ export interface Options {
   /**
    * Path for directories to be auto imported
    */
-  dirs?: string[]
+  dirs?: (string | DirsOptions)[]
 
   /**
    * Pass a custom function to resolve the component importing path from the component name.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Added `exportAllByFileName` configuration for `dirs`, which allows for importing all by file names instead of scanning the file contents when generating type declarations and automatically importing. The detailed problem description can be found in issue #388.

### Linked Issues

#388 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
