### PR TITLE
fix: dirs config support rspack

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "magic-string": "^0.30.0",
     "minimatch": "^9.0.1",
     "unimport": "^3.0.8",
-    "unplugin": "^1.3.1"
+    "unplugin": "^1.3.2"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.39.5",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I found that the `dirs` configuration uses the `buildStart` hook, but the previous version of `unplugin` did not implement `buildStart` for rspack. So, I fixed the `unplugin` code, and now it's necessary to update the `unplugin` version of this plugin.

