### PR TITLE
fix: resolve `@antfu/utils` types in dts output

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,4 +3,7 @@ import { defineConfig } from 'tsdown'
 export default defineConfig({
   entry: ['src/*.ts'],
   format: ['esm', 'cjs'],
+  dts: {
+    resolve: ['@antfu/utils'],
+  },
 })


### PR DESCRIPTION
### Description

Fix type resolution for the `imports` option — it was showing as `any` in TypeScript.

This PR updates the tsdown config to bundle `@antfu/utils` types in the generated `.d.ts` output:

```ts
dts: {
  resolve: ['@antfu/utils'],
},
```

This ensures proper type inference for the imports option and exposes supported presets correctly.

### Linked Issues

Fixes #606