### PR TITLE
perf: precompile picomatch matchers once per context

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -6,6 +6,7 @@ import process from 'node:process'
 import { isString, slash, throttle, toArray } from '@antfu/utils'
 import { isPackageExists } from 'local-pkg'
 import MagicString from 'magic-string'
+import pm from 'picomatch'
 import { createUnimport, normalizeScanDirs, resolvePreset } from 'unimport'
 import { createFilter } from 'unplugin-utils'
 import { presets } from '../presets'
@@ -297,6 +298,8 @@ ${dts}`.trim()}\n`
       }))
     : []
 
+  const normalizedDirMatchers = normalizedDirPaths.map(dir => pm(dir.glob))
+
   return {
     root,
     dirs,
@@ -309,7 +312,7 @@ ${dts}`.trim()}\n`
     generateESLint,
     unimport,
     configFilePaths,
-    normalizedDirPaths,
+    normalizedDirMatchers,
   }
 }
 

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -2,7 +2,6 @@ import type { FilterPattern } from 'unplugin'
 import type { Options } from '../types'
 import { slash } from '@antfu/utils'
 import { isPackageExists } from 'local-pkg'
-import pm from 'picomatch'
 import { createUnplugin } from 'unplugin'
 import { createContext, EXCLUDE_RE_LIST, INCLUDE_RE_LIST } from './ctx'
 
@@ -58,9 +57,7 @@ export default createUnplugin<Options>((options) => {
 
         const normalizedFilePath = slash(file)
 
-        const shouldRescan = ctx.normalizedDirPaths.some(dirPath =>
-          pm.isMatch(normalizedFilePath, dirPath.glob),
-        )
+        const shouldRescan = ctx.normalizedDirMatchers.some(match => match(normalizedFilePath))
 
         if (shouldRescan)
           await ctx.scanDirs()


### PR DESCRIPTION
### Description

This PR precompiles `picomatch` matchers once at context creation instead of rebuilding them on every `pm.isMatch(file, glob)` call inside `handleHotUpdate`.

Mirrors the same optimization in [unjs/unimport#535](https://github.com/unjs/unimport/pull/535).