### PR TITLE
fix(biome): respect disabled lint config

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -35,7 +35,7 @@ export function createContext(options: Options = {}, root = process.cwd()) {
   eslintrc.globalsPropValue = eslintrc.globalsPropValue === undefined ? true : eslintrc.globalsPropValue
 
   const biomelintrc: BiomeLintrc = options.biomelintrc || {}
-  biomelintrc.enabled = biomelintrc.enabled !== undefined
+  biomelintrc.enabled = biomelintrc.enabled === undefined ? false : biomelintrc.enabled
   biomelintrc.filepath = biomelintrc.filepath || './.biomelintrc-auto-import.json'
 
   const dumpUnimportItems = options.dumpUnimportItems === true

--- a/test/biomelintrc.test.ts
+++ b/test/biomelintrc.test.ts
@@ -1,0 +1,26 @@
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it } from 'vitest'
+import { createContext } from '../src/core/ctx'
+
+it('does not generate Biome config when disabled', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'unplugin-auto-import-'))
+  const output = join(root, '.biomelintrc-auto-import.json')
+
+  try {
+    const ctx = createContext({
+      dts: false,
+      imports: [{ custom: ['foo'] }],
+      biomelintrc: { enabled: false, filepath: output },
+    }, root)
+
+    await ctx.writeConfigFiles()
+
+    expect(existsSync(output)).toBe(false)
+  }
+  finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

This PR preserves an explicit `biomelintrc.enabled: false` value so the plugin no longer generates `.biomelintrc-auto-import.json` when Biome config generation is disabled.

## Why

`biomelintrc.enabled !== undefined` treated both `true` and `false` as enabled.
