### PR TITLE
feat!: support React Router v8 in the `react-router` preset

### DIFF
--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -14,8 +14,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-i18next": "^17.0.11",
-    "react-router": "^7.18.2",
-    "react-router-dom": "^7.18.2"
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@iconify-json/logos": "*",

--- a/examples/vite-react/src/main.tsx
+++ b/examples/vite-react/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(

--- a/examples/vite-react/vite.config.ts
+++ b/examples/vite-react/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       jsx: 'react',
     }),
     AutoImport({
-      imports: ['react', 'react-router-dom', 'react-i18next', 'ahooks'],
+      imports: ['react', 'react-router', 'react-i18next', 'ahooks'],
       dts: './src/auto-imports.d.ts',
       dirs: ['src/layouts', 'src/views'],
       eslintrc: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,11 +173,8 @@ importers:
         specifier: ^17.0.11
         version: 17.0.11(i18next@26.3.6(typescript@5.9.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       react-router:
-        specifier: ^7.18.2
-        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-router-dom:
-        specifier: ^7.18.2
-        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@iconify-json/logos':
         specifier: '*'
@@ -2418,9 +2415,8 @@ packages:
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie@2.0.1:
     resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
@@ -3871,19 +3867,12 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@7.18.2:
-    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.2:
-    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -4025,9 +4014,6 @@ packages:
   seroval@1.5.6:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -7064,7 +7050,7 @@ snapshots:
 
   cookie-es@1.2.3: {}
 
-  cookie@1.1.1: {}
+  cookie-es@3.1.1: {}
 
   cookie@2.0.1: {}
 
@@ -8652,17 +8638,10 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-router-dom@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
+      cookie-es: 3.1.1
       react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-
-  react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.8
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
 
@@ -8834,8 +8813,6 @@ snapshots:
       seroval: 1.5.6
 
   seroval@1.5.6: {}
-
-  set-cookie-parser@2.7.2: {}
 
   sharp@0.34.5:
     dependencies:

--- a/src/presets/react-router-dom.ts
+++ b/src/presets/react-router-dom.ts
@@ -3,7 +3,10 @@ import { ReactRouterDomExports, ReactRouterHooks } from './react-router'
 
 /**
  * Only compatible with React Router Dom v6 and v7.
- * The package was removed in v8 — use the `react-router` preset instead.
+ *
+ * @deprecated `react-router-dom` was removed in React Router v8, where its
+ * exports moved into `react-router`. Kept for v6 and v7 users; on v8 use the
+ * `react-router` preset instead.
  */
 export default <ImportsMap>({
   'react-router-dom': [

--- a/src/presets/react-router-dom.ts
+++ b/src/presets/react-router-dom.ts
@@ -1,29 +1,13 @@
 import type { ImportsMap } from '../types'
-import { ReactRouterHooks } from './react-router'
+import { ReactRouterDomExports, ReactRouterHooks } from './react-router'
 
 /**
- * Only compatible with React Router Dom v6.
+ * Only compatible with React Router Dom v6 and v7.
+ * The package was removed in v8 — use the `react-router` preset instead.
  */
 export default <ImportsMap>({
   'react-router-dom': [
     ...ReactRouterHooks,
-
-    // react-router-dom only hooks
-    'useLinkClickHandler',
-    'useSearchParams',
-
-    // react-router-dom Component
-
-    // call once in general
-    // 'BrowserRouter',
-    // 'HashRouter',
-    // 'MemoryRouter',
-
-    'Link',
-    'NavLink',
-    'Navigate',
-    'Outlet',
-    'Route',
-    'Routes',
+    ...ReactRouterDomExports,
   ],
 })

--- a/src/presets/react-router.ts
+++ b/src/presets/react-router.ts
@@ -1,7 +1,7 @@
 import type { ImportsMap } from '../types'
 
 /**
- * Only compatible with React Router v6.
+ * Available from React Router v6.
  */
 export const ReactRouterHooks = [
   'useOutletContext',
@@ -16,8 +16,35 @@ export const ReactRouterHooks = [
   'useRoutes',
 ]
 
+/**
+ * Lived in `react-router-dom` until v7, moved into `react-router` in v8.
+ */
+export const ReactRouterDomExports = [
+  'useLinkClickHandler',
+  'useSearchParams',
+
+  // components
+
+  // call once in general
+  // 'BrowserRouter',
+  // 'HashRouter',
+  // 'MemoryRouter',
+
+  'Link',
+  'NavLink',
+  'Navigate',
+  'Outlet',
+  'Route',
+  'Routes',
+]
+
+/**
+ * Only compatible with React Router v8, where `react-router-dom` was merged in.
+ * For v6 and v7, use the `react-router-dom` preset instead.
+ */
 export default <ImportsMap>({
   'react-router': [
     ...ReactRouterHooks,
+    ...ReactRouterDomExports,
   ],
 })


### PR DESCRIPTION
## Why

`react-router-dom` has no v8 — the package was removed in that major and everything it exported moved into `react-router` itself. The `react-router` preset only lists the v6 hooks, so on v8 it no longer covers the components and hooks users actually need.

Split out of the dependency-update sweep on `main` because it is a breaking change to a shipped preset.

## What

Extracts the names that used to be `react-router-dom`-only into `ReactRouterDomExports` and spreads them into both presets. The `react-router` preset now also covers:

`Link` · `NavLink` · `Navigate` · `Outlet` · `Route` · `Routes` · `useSearchParams` · `useLinkClickHandler`

`BrowserRouter` / `HashRouter` / `MemoryRouter` stay commented out, as before — they are called once and are not a good fit for auto-import.

The `vite-react` example is migrated onto react-router v8: `react-router-dom` dropped from its dependencies, `BrowserRouter` imported from `react-router`, and the preset name updated in its `vite.config.ts`.

## The `react-router-dom` preset is kept

It is **not** removed, and its resolved import list is byte-identical to before — only its construction changed, so it now shares the two extracted arrays. v6 and v7 users who use that preset are unaffected.

It carries a `@deprecated` tag recording that the package is gone in v8 and pointing at the `react-router` preset. Note this is source-level documentation: presets are bundled internals, so the tag does not reach the published `.d.mts`, and the public `PresetName` string union cannot carry per-member deprecation. README already points readers at [`src/presets`](../tree/main/src/presets) directly.

## ⚠️ Breaking

The `react-router` preset's output is unconditional — it always returns the v8 list. Those names are **not** on `react-router`'s main entry in v6 or v7, so consumers on those majors who use the `react-router` preset will get generated imports that do not resolve.

**Migration:** switch to the `react-router-dom` preset, which is unchanged.

This was a deliberate choice over making `react-router` a version-aware function preset (which the codebase supports — see `@vueuse/core`): keeping the output static means preset results stay predictable and independent of install state.

## Verification

`build`, `typecheck`, `lint` and all 41 tests pass. Every example and the playground build, including `tsc && vite build` for `vite-react`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)